### PR TITLE
Add video transcription script for Azure Speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Azure Speech Project
+
+This small project demonstrates how to transcribe a video file using
+Azure Speech Service and save the result as an SRT subtitle file.
+
+## Setup
+
+1. Install the dependencies:
+   ```bash
+   pip install azure-cognitiveservices-speech python-dotenv
+   ```
+2. Create a `.env` file next to your script with the following variables:
+   ```
+   SPEECH_KEY=your-azure-speech-key
+   SPEECH_REGION=your-service-region
+   ```
+3. Ensure `ffmpeg` is installed and available in your `PATH` for converting
+   video files to audio.
+
+## Usage
+
+Run the module directly and pass the video file and the desired SRT output:
+
+```bash
+python -m azure_speech_project path/to/video.mp4 subtitles.srt
+```
+
+The script will extract the audio from the video, send it to Azure Speech
+Service for transcription and create the `subtitles.srt` file with time
+codes.

--- a/src/azure_speech_project/__init__.py
+++ b/src/azure_speech_project/__init__.py
@@ -1,0 +1,5 @@
+"""Simple utilities to transcribe videos using Azure Speech."""
+
+from .transcribe import convert_video_to_wav, transcribe_wav_to_srt
+
+__all__ = ["convert_video_to_wav", "transcribe_wav_to_srt"]

--- a/src/azure_speech_project/__main__.py
+++ b/src/azure_speech_project/__main__.py
@@ -1,0 +1,4 @@
+from .transcribe import main
+
+if __name__ == "__main__":
+    main()

--- a/src/azure_speech_project/transcribe.py
+++ b/src/azure_speech_project/transcribe.py
@@ -1,0 +1,92 @@
+import subprocess
+import os
+import time
+from pathlib import Path
+
+from dotenv import load_dotenv
+import azure.cognitiveservices.speech as speechsdk
+
+
+def convert_video_to_wav(video_path: Path, wav_path: Path) -> None:
+    """Convert a video file to wav audio using ffmpeg."""
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(video_path),
+        "-vn",
+        "-acodec",
+        "pcm_s16le",
+        str(wav_path),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def seconds_to_srt_time(seconds: float) -> str:
+    hours = int(seconds // 3600)
+    minutes = int((seconds % 3600) // 60)
+    secs = int(seconds % 60)
+    millis = int(round((seconds - int(seconds)) * 1000))
+    return f"{hours:02}:{minutes:02}:{secs:02},{millis:03}"
+
+
+def transcribe_wav_to_srt(wav_path: Path, srt_path: Path, speech_key: str, service_region: str) -> None:
+    speech_config = speechsdk.SpeechConfig(subscription=speech_key, region=service_region)
+    speech_config.output_format = speechsdk.OutputFormat.Detailed
+    speech_config.request_word_level_timestamps()
+    audio_input = speechsdk.AudioConfig(filename=str(wav_path))
+    recognizer = speechsdk.SpeechRecognizer(speech_config=speech_config, audio_config=audio_input)
+
+    results = []
+    done = False
+
+    def recognized(evt: speechsdk.SpeechRecognitionEventArgs):
+        nonlocal results
+        if evt.result.reason == speechsdk.ResultReason.RecognizedSpeech:
+            offset = evt.result.offset / 10 ** 7  # 100-ns ticks to seconds
+            duration = evt.result.duration / 10 ** 7
+            text = evt.result.text
+            results.append((offset, offset + duration, text))
+
+    def stop(evt):
+        nonlocal done
+        done = True
+
+    recognizer.recognized.connect(recognized)
+    recognizer.session_stopped.connect(stop)
+    recognizer.canceled.connect(stop)
+
+    recognizer.start_continuous_recognition()
+    while not done:
+        time.sleep(0.5)
+    recognizer.stop_continuous_recognition()
+
+    with open(srt_path, "w", encoding="utf-8") as f:
+        for idx, (start, end, text) in enumerate(results, 1):
+            f.write(f"{idx}\n")
+            f.write(f"{seconds_to_srt_time(start)} --> {seconds_to_srt_time(end)}\n")
+            f.write(f"{text}\n\n")
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Transcribe a video to SRT using Azure Speech Service")
+    parser.add_argument("video", type=Path, help="Path to the input video file")
+    parser.add_argument("output", type=Path, help="Path to the output SRT file")
+    args = parser.parse_args()
+
+    load_dotenv()
+    speech_key = os.getenv("SPEECH_KEY")
+    service_region = os.getenv("SPEECH_REGION")
+    if not speech_key or not service_region:
+        raise RuntimeError("SPEECH_KEY and SPEECH_REGION must be set in environment or .env")
+
+    wav_path = args.output.with_suffix(".wav")
+    convert_video_to_wav(args.video, wav_path)
+    transcribe_wav_to_srt(wav_path, args.output, speech_key, service_region)
+    wav_path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `transcribe.py` to convert video to WAV, transcribe with Azure Speech and generate SRT subtitles
- expose CLI entry via `__main__`
- document project setup and usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685269b11f20832f88b7ca252d0a081e